### PR TITLE
changed Keras.application to latest form in import statements

### DIFF
--- a/resnet101.py
+++ b/resnet101.py
@@ -30,7 +30,7 @@ from keras.utils import layer_utils
 from keras import initializers
 from keras.engine import Layer, InputSpec
 from keras.utils.data_utils import get_file
-from keras.applications.imagenet_utils import _obtain_input_shape
+from keras_applications.imagenet_utils import _obtain_input_shape
 
 import sys
 

--- a/resnet152.py
+++ b/resnet152.py
@@ -30,7 +30,7 @@ from keras.utils import layer_utils
 from keras import initializers
 from keras.engine import Layer, InputSpec
 from keras.utils.data_utils import get_file
-from keras.applications.imagenet_utils import _obtain_input_shape
+from keras_applications.imagenet_utils import _obtain_input_shape
 
 import sys
 

--- a/vgg16_hybrid_places_1365.py
+++ b/vgg16_hybrid_places_1365.py
@@ -23,7 +23,7 @@ from keras.regularizers import l2
 from keras.layers.core import Dropout
 from keras.layers import GlobalAveragePooling2D
 from keras.layers import GlobalMaxPooling2D
-from keras.applications.imagenet_utils import _obtain_input_shape
+from keras_applications.imagenet_utils import _obtain_input_shape
 from keras.engine.topology import get_source_inputs
 from keras.utils.data_utils import get_file
 from keras.utils import layer_utils

--- a/vgg16_places_365.py
+++ b/vgg16_places_365.py
@@ -21,7 +21,7 @@ from keras.regularizers import l2
 from keras.layers.core import Dropout
 from keras.layers import GlobalAveragePooling2D
 from keras.layers import GlobalMaxPooling2D
-from keras.applications.imagenet_utils import _obtain_input_shape
+from keras_applications.imagenet_utils import _obtain_input_shape
 from keras.engine.topology import get_source_inputs
 from keras.utils.data_utils import get_file
 from keras.utils import layer_utils


### PR DESCRIPTION
I changed Keras.applications in the import statements for importing _obtain_input_shape to Keras_application as the previous was deprecated.